### PR TITLE
Remove input variable coercion since it is done again later

### DIFF
--- a/leto/lib/leto.dart
+++ b/leto/lib/leto.dart
@@ -341,13 +341,11 @@ class GraphQL {
       }
     }
 
-    final coercedVariableValues =
-        coerceVariableValues(schema, operation, variableValues);
     final ctx = ExecutionCtx(
       document: document,
       operation: operation,
       scope: globalVariables,
-      variableValues: coercedVariableValues,
+      variableValues: variableValues ?? {},
       requestCtx: baseCtx,
     );
     _resolveCtxRef.get(ctx.scope).value = ctx;
@@ -398,82 +396,6 @@ class GraphQL {
         ),
       );
     }
-  }
-
-  Map<String, dynamic> coerceVariableValues(
-    GraphQLSchema schema,
-    OperationDefinitionNode operation,
-    Map<String, dynamic>? variableValues,
-  ) {
-    final coercedValues = <String, dynamic>{};
-    final variableDefinitions = operation.variableDefinitions;
-
-    for (final variableDefinition in variableDefinitions) {
-      final variableName = variableDefinition.variable.name.value;
-      final variableType = variableDefinition.type;
-      final type = convertType(variableType, schema.typeMap);
-      final span = variableDefinition.span ??
-          variableDefinition.variable.span ??
-          variableDefinition.variable.name.span;
-      final locations = GraphQLErrorLocation.listFromSource(
-        span?.start,
-      );
-
-      if (!isInputType(type)) {
-        throw GraphQLError(
-          'Variable "$variableName" expected value of type "$type"'
-          ' which cannot be used as an input type.',
-          locations: locations,
-        );
-      }
-
-      final defaultValue = variableDefinition.defaultValue;
-      if (variableValues == null || !variableValues.containsKey(variableName)) {
-        if (defaultValue?.value != null) {
-          coercedValues[variableName] = computeValue(
-            type,
-            defaultValue!.value!,
-            variableValues,
-          );
-        }
-      } else {
-        final Object? value = variableValues[variableName];
-        if (value == null) {
-          if (variableValues.containsKey(variableName)) {
-            coercedValues[variableName] = null;
-          }
-        } else {
-          // TODO: 3I should we just deserialize with a result?
-          final validation = type.validate(variableName, value);
-
-          if (!validation.successful) {
-            throw GraphQLException(
-              validation.errors
-                  .map((e) => GraphQLError(e, locations: locations))
-                  .toList(),
-            );
-          } else {
-            final Object? coercedValue = type.deserialize(
-              schema.serdeCtx,
-              // Nullability change was validation.value!
-              validation.value,
-            );
-            coercedValues[variableName] = coercedValue;
-          }
-        }
-      }
-      if (variableType.isNonNull && coercedValues[variableName] == null) {
-        throw GraphQLException.fromMessage(
-          coercedValues.containsKey(variableName)
-              ? 'Required variable "$variableName" of'
-                  ' type $type must not be null.'
-              : 'Missing required variable "$variableName" of type $type',
-          location: span?.start,
-        );
-      }
-    }
-
-    return coercedValues;
   }
 
   Future<Map<String, dynamic>> executeQuery(
@@ -968,27 +890,7 @@ class GraphQL {
             argumentValue.span ??
             argumentValue.value.span ??
             argumentValue.name.span;
-        if (node is VariableNode) {
-          /// variable values where already validated and
-          /// coerced in [coerceVariableValues]
-          final variableName = node.name.value;
-          final Object? value = variableValues.containsKey(variableName)
-              ? variableValues[variableName]
-              : defaultValue;
-          coercedValues[argumentName] = value;
-          if (value == null && argumentType.isNonNullable) {
-            throw GraphQLException.fromMessage(
-              variableValues.containsKey(variableName)
-                  ? 'Variable value for argument "$argumentName" of type $argumentType'
-                      ' for field "$fieldName" must not be null.'
-                  : 'Missing variable "$variableName" for argument'
-                      ' "$argumentName" of type $argumentType'
-                      ' for field "$fieldName".',
-              location: span?.start,
-            );
-          }
-          continue;
-        }
+
         final value = computeValue(
           argumentType,
           node,

--- a/leto/test/executor/serialized_types.dart
+++ b/leto/test/executor/serialized_types.dart
@@ -1,0 +1,108 @@
+// This ia code that uses custom serializers in the same way the leto_generator
+// creates objects with serialziers via Annotations
+
+
+import 'package:leto_schema/leto_schema.dart';
+
+GraphQLObjectField<bool, Object?, Object?> get testMutationGraphQLField => _testMutationGraphQLField.value;
+final _testMutationGraphQLField = HotReloadableDefinition<GraphQLObjectField<bool, Object?, Object?>>(
+    (setValue) => setValue(graphQLBoolean.nonNull().field<Object?>(
+          'testMutation',
+          resolve: (obj, ctx) {
+            final args = ctx.args;
+            return true;
+          },
+        ))
+          ..inputs.addAll([
+            testInputGraphQLTypeInput.nonNull().inputField('input'),
+            graphQLInt.nonNull().inputField('num'),
+            graphQLBoolean.nonNull().inputField('isATest')
+          ]));
+
+GraphQLInputObjectType<TestInput> get testInputGraphQLTypeInput => _testInputGraphQLTypeInput.value;
+
+final _testInputGraphQLTypeInput = HotReloadableDefinition<GraphQLInputObjectType<TestInput>>((setValue) {
+  final __name = 'TestInput';
+
+  final __testInputGraphQLTypeInput = inputObjectType<TestInput>(__name);
+
+  setValue(__testInputGraphQLTypeInput);
+  __testInputGraphQLTypeInput.fields.addAll(
+    [
+      graphQLString.nonNull().inputField('words'),
+      testValueGraphQLTypeInput.inputField('value'),
+      testValueGraphQLTypeInput.inputField('value2'),
+    ],
+  );
+
+  return __testInputGraphQLTypeInput;
+});
+
+GraphQLInputObjectType<TestValue> get testValueGraphQLTypeInput => _testValueGraphQLTypeInput.value;
+
+final _testValueGraphQLTypeInput = HotReloadableDefinition<GraphQLInputObjectType<TestValue>>((setValue) {
+  final __name = 'TestValue';
+
+  final __testValueGraphQLTypeInput = inputObjectType<TestValue>(__name);
+
+  setValue(__testValueGraphQLTypeInput);
+  __testValueGraphQLTypeInput.fields.addAll(
+    [graphQLString.nonNull().inputField('value')],
+  );
+
+  return __testValueGraphQLTypeInput;
+});
+
+class TestInput {
+  String words;
+  TestValue? value;
+  TestValue? value2;
+
+  TestInput(this.words, this.value, this.value2);
+
+  factory TestInput.fromJson(Map<String, dynamic> json) => _$TestInputFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TestInputToJson(this);
+}
+
+class TestValue {
+  final String value;
+
+  TestValue(this.value);
+
+  factory TestValue.fromJson(Map<String, dynamic> json) => _$TestValueFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TestValueToJson(this);
+}
+
+TestValue _$TestValueFromJson(Map<String, dynamic> json) => TestValue(
+      json['value'] as String,
+    );
+
+Map<String, dynamic> _$TestValueToJson(TestValue instance) => <String, dynamic>{
+      'value': instance.value,
+    };
+
+TestInput _$TestInputFromJson(Map<String, dynamic> json) => TestInput(
+      json['words'] as String,
+      json['value'] == null ? null : TestValue.fromJson(json['value'] as Map<String, dynamic>),
+      json['value2'] == null ? null : TestValue.fromJson(json['value2'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$TestInputToJson(TestInput instance) => <String, dynamic>{
+      'words': instance.words,
+      'value': instance.value,
+      'value2': instance.value2,
+    };
+
+final testValueSerializer = SerializerValue<TestValue>(
+  key: "TestValue",
+  fromJson: (ctx, json) => TestValue.fromJson(json), // _$$FromJson,
+  // toJson: (m) => _$$ToJson(m as _$),
+);
+
+final testInputSerializer = SerializerValue<TestInput>(
+  key: "TestInput",
+  fromJson: (ctx, json) => TestInput.fromJson(json), // _$$FromJson,
+  // toJson: (m) => _$$ToJson(m as _$),
+);

--- a/leto_schema/lib/src/type.dart
+++ b/leto_schema/lib/src/type.dart
@@ -270,7 +270,7 @@ class _GraphQLNonNullListType<Value, Serialized>
   }
 
   @override
-  List<Value> deserialize(SerdeCtx serdeCtx, List<Serialized?> serialized) {
+  List<Value> deserialize(SerdeCtx serdeCtx, List<dynamic> serialized) {
     return serialized
         .map<Value>(
           (v) => v is Value
@@ -348,7 +348,7 @@ class _GraphQLNullableListType<Value, Serialized>
   }
 
   @override
-  List<Value?> deserialize(SerdeCtx serdeCtx, List<Serialized?> serialized) {
+  List<Value?> deserialize(SerdeCtx serdeCtx, List<dynamic> serialized) {
     if (ofType.isNonNullable) {
       return serialized
           .map<Value>(
@@ -362,7 +362,7 @@ class _GraphQLNullableListType<Value, Serialized>
     return serialized
         .map<Value?>(
           // ignore: unnecessary_cast
-          (v) => v is Value? ? v as Value? : ofType.deserialize(serdeCtx, v),
+          (v) => v is Value? ? v as Value? : ofType.deserialize(serdeCtx, v as Serialized),
         )
         .toList();
   }


### PR DESCRIPTION
When an incoming query is processed input coercion and  validation is run on all inputs.

Since variables are coerced and validated separately, when the input is processed the types have already been coerced and validation fails if they are object types.

This removes variable coercion and follows the same process for all inputs.